### PR TITLE
Kjq/fix json query

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -1,15 +1,15 @@
 /*
  * == BSD2 LICENSE ==
  * Copyright (c) 2014, Tidepool Project
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the associated License, which is identical to the BSD 2-Clause
  * License as published by the Open Source Initiative at opensource.org.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the License for more details.
- * 
+ *
  * You should have received a copy of the License along with this program; if
  * not, you can obtain one from Tidepool Project at tidepool.org.
  * == BSD2 LICENSE ==
@@ -98,7 +98,7 @@ module.exports = function createHttpClient(config, request) {
           return this;
         },
         withJson: function(json) {
-          return this.withContentType('application/json').withBody(JSON.stringify(json));
+          return this.withContentType('application/json').withBody(json);
         },
         withQuery: function(queryObj) {
           options.qs = queryObj;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amoeba",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Common library for tidepool.org",
   "keywords": [
     "common",


### PR DESCRIPTION
@jh-bate @jebeck Turns out that the request library doesn't want us to pre-stringify JSON objects before passing them to request(). The only place this is used in our codebase is in gatekeeper-client, and only in the setPermissions call -- which is only called from Zuul. That's why this only failed in one place.

