### PR TITLE
Add a mongo support module

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@
 exports.arrays = require('./lib/arrays.js');
 exports.base32hex = require('./lib/base32hex.js');
 exports.config = require('./lib/config.js');
+exports.mongo = require('./lib/mongo.js');
 exports.except = require('./lib/except.js');
 exports.files = require('./lib/files.js');
 exports.httpClient = require('./lib/httpClient.js');

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -1,0 +1,58 @@
+// == BSD2 LICENSE ==
+// Copyright (c) 2019, Tidepool Project
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the associated License, which is identical to the BSD 2-Clause
+// License as published by the Open Source Initiative at opensource.org.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the License for more details.
+//
+// You should have received a copy of the License along with this program; if
+// not, you can obtain one from Tidepool Project at tidepool.org.
+// == BSD2 LICENSE ==
+
+'use strict';
+
+exports.toConnectionString = function(defaultDB) {
+  cs = "mongodb://"
+  user = process.env['MONGO_USER']
+  if (user != null) {
+    cs += user
+    password = process.env['MONGO_PASSWORD']
+    if (password != null) {
+      cs += ":"
+      cs += password
+    }
+    cs += "@"
+  }
+
+  hosts = process.env['MONGO_HOSTS']
+  if (hosts != null) {
+    cs += hosts
+    cs += "/"
+  } else {
+    cs += "localhost/"
+  }
+
+  database = process.env['MONGO_DATABASE']
+  if (database != null) {
+    cs += database
+  } else {
+    cs += defaultDB
+  }
+
+  ssl = process.env['MONGO_SSL']
+  if (ssl != null && ssl.toLowerCase() == "true") {
+    cs += "?ssl=true"
+  } else {
+    cs += "?ssl=false"
+  }
+  optParams = process.env['MONGO_OPT_PARAMS']
+  if (optParams != null) {
+    cs += "&"
+    cs += optParams
+  }
+  return cs
+}

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -15,44 +15,48 @@
 
 'use strict';
 
-exports.toConnectionString = function(defaultDB) {
-  cs = "mongodb://"
-  user = process.env['MONGO_USER']
+exports.toConnectionString = function(defaultDB, obj) {
+  if (obj == null) {
+    obj = process.env;
+  }
+  var cs = 'mongodb://';
+  var user = obj.MONGO_USER;
   if (user != null) {
-    cs += user
-    password = process.env['MONGO_PASSWORD']
+    cs += user;
+    var password = obj.MONGO_PASSWORD;
     if (password != null) {
-      cs += ":"
-      cs += password
+      cs += ':';
+      cs += password;
     }
-    cs += "@"
+    cs += '@';
   }
 
-  hosts = process.env['MONGO_HOSTS']
+  var hosts = obj.MONGO_HOSTS;
   if (hosts != null) {
-    cs += hosts
-    cs += "/"
+    cs += hosts;
+    cs += '/';
   } else {
-    cs += "localhost/"
+    cs += 'localhost/';
   }
 
-  database = process.env['MONGO_DATABASE']
+  var database = obj.MONGO_DATABASE;
   if (database != null) {
-    cs += database
+    cs += database;
   } else {
-    cs += defaultDB
+    cs += defaultDB;
   }
 
-  ssl = process.env['MONGO_SSL']
-  if (ssl != null && ssl.toLowerCase() == "true") {
-    cs += "?ssl=true"
+  var ssl = obj.MONGO_SSL;
+  if (ssl != null && ssl.toLowerCase() == 'true') {
+    cs += '?ssl=true';
   } else {
-    cs += "?ssl=false"
+    cs += '?ssl=false';
   }
-  optParams = process.env['MONGO_OPT_PARAMS']
+
+  var optParams = obj.MONGO_OPT_PARAMS;
   if (optParams != null) {
-    cs += "&"
-    cs += optParams
+    cs += '&';
+    cs += optParams;
   }
-  return cs
-}
+  return cs;
+};

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -16,7 +16,7 @@
 'use strict';
 
 exports.toConnectionString = function(defaultDB, obj) {
-  if (obj == null) {
+  if (obj == undefined) {
     obj = process.env;
   }
   var cs = 'mongodb://';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amoeba",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Common library for tidepool.org",
   "keywords": [
     "common",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amoeba",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Common library for tidepool.org",
   "keywords": [
     "common",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amoeba",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Common library for tidepool.org",
   "keywords": [
     "common",

--- a/test/testMongo.js
+++ b/test/testMongo.js
@@ -46,4 +46,9 @@ describe('mongo.js', function(){
       var obj={ MONGO_USER: 'derrick', MONGO_PASSWORD: 'password', MONGO_SSL: 'True', MONGO_OPT_PARAMS: 'x=y'};
       expect(cs('foo', obj)).to.deep.equal('mongodb://derrick:password@localhost/foo?ssl=true&x=y');
     });
+
+    it('returns simple connection string with USER and PASSWORD and ssl and optparams and hosts', function() {
+      var obj={ MONGO_USER: 'derrick', MONGO_PASSWORD: 'password', MONGO_SSL: 'True', MONGO_OPT_PARAMS: 'x=y', MONGO_HOSTS: 'mongodb1,mongodb2'};
+      expect(cs('foo', obj)).to.deep.equal('mongodb://derrick:password@mongodb1,mongodb2/foo?ssl=true&x=y');
+    });
 });

--- a/test/testMongo.js
+++ b/test/testMongo.js
@@ -1,0 +1,49 @@
+// == BSD2 LICENSE ==
+// Copyright (c) 2014, Tidepool Project
+// 
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the associated License, which is identical to the BSD 2-Clause
+// License as published by the Open Source Initiative at opensource.org.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the License for more details.
+// 
+// You should have received a copy of the License along with this program; if
+// not, you can obtain one from Tidepool Project at tidepool.org.
+// == BSD2 LICENSE ==
+
+// expect violates this jshint thing a lot, so we just suppress it
+/* jshint expr: true */
+
+'use strict';
+
+var expect = require('salinity').expect;
+
+var cs = require('../lib/mongo.js').toConnectionString;
+
+describe('mongo.js', function(){
+    it('returns simple connection string with no args', function() {
+      expect(cs('foo')).to.deep.equal('mongodb://localhost/foo?ssl=false');
+    });
+
+    it('returns simple connection string with USER', function() {
+      var obj={ MONGO_USER: 'derrick'};
+      expect(cs('foo', obj)).to.deep.equal('mongodb://derrick@localhost/foo?ssl=false');
+    });
+
+    it('returns simple connection string with USER and PASSWORD', function() {
+      var obj={ MONGO_USER: 'derrick', MONGO_PASSWORD: 'password'};
+      expect(cs('foo', obj)).to.deep.equal('mongodb://derrick:password@localhost/foo?ssl=false');
+    });
+
+    it('returns simple connection string with USER and PASSWORD and ssl', function() {
+      var obj={ MONGO_USER: 'derrick', MONGO_PASSWORD: 'password', MONGO_SSL: 'True'};
+      expect(cs('foo', obj)).to.deep.equal('mongodb://derrick:password@localhost/foo?ssl=true');
+    });
+
+    it('returns simple connection string with USER and PASSWORD and ssl and optparams', function() {
+      var obj={ MONGO_USER: 'derrick', MONGO_PASSWORD: 'password', MONGO_SSL: 'True', MONGO_OPT_PARAMS: 'x=y'};
+      expect(cs('foo', obj)).to.deep.equal('mongodb://derrick:password@localhost/foo?ssl=true&x=y');
+    });
+});


### PR DESCRIPTION
This is used for creating a connection string from individual environment variables. 

One could argue that it should be in its own repo, but who wants to deal with that. :)

On the bright side, I did write unit tests!  They pass.